### PR TITLE
Updated nuget.exe usage to look in path first

### DIFF
--- a/DbUpMigration/task/Update-DatabaseWithDbUp.ps1
+++ b/DbUpMigration/task/Update-DatabaseWithDbUp.ps1
@@ -30,6 +30,10 @@ function Install-DbUpAndGetDllPath {
         
         & $nuget install dbup | Out-Null
 
+        if (Test-Path .\nuget.exe) {
+            rm .\nuget.exe
+        }
+
         cd $oldLocation
     }
     return Resolve-Path $dllFilePattern | select -ExpandProperty Path -First 1

--- a/DbUpMigration/task/Update-DatabaseWithDbUp.ps1
+++ b/DbUpMigration/task/Update-DatabaseWithDbUp.ps1
@@ -19,9 +19,17 @@ function Install-DbUpAndGetDllPath {
     if (-not (Test-Path $dllFilePattern)) {
         $oldLocation = Get-Location
         cd $workingDir
-        wget http://nuget.org/nuget.exe -OutFile nuget.exe -UseBasicParsing
-        .\nuget.exe install dbup | Out-Null
-        rm nuget.exe
+        
+        # Check if nuget.exe is already in the path and use that
+        $nuget = Get-Command "nuget.exe" -ErrorAction SilentlyContinue
+        if ($nuget -eq $null) {
+            # nuget.exe not in path, download it
+            wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile nuget.exe -UseBasicParsing
+            $nuget = ".\nuget.exe"
+        }
+        
+        & $nuget install dbup | Out-Null
+
         cd $oldLocation
     }
     return Resolve-Path $dllFilePattern | select -ExpandProperty Path -First 1


### PR DESCRIPTION
I added some code to first check if nuget.exe is in the path.  I'd imagine on some build servers, downloading nuget.exe is unnecessary and this method would allow users of the task to get around the issue of the user profile temp folder being locked by group policy (by installing nuget.exe in the path instead).  I also updated the URL for downloading the latest nuget.exe.

RE: #17