### PR TITLE
Issue WithVariablesDisabled() when variable substitution is not configfured

### DIFF
--- a/DbUpMigration/task/Update-DatabaseWithDbUp.ps1
+++ b/DbUpMigration/task/Update-DatabaseWithDbUp.ps1
@@ -230,6 +230,9 @@ function Update-DatabaseWithDbUp {
             $dbUp = [StandardExtensions]::WithVariable($dbUp, $name, $_.Value);
         }
     }
+    else {
+        $dbUp = [StandardExtensions]::WithVariablesDisabled($dbUp);
+    }
     $result = $dbUp.Build().PerformUpgrade()
     if (!$result.Successful) {
         $errorMessage = ""


### PR DESCRIPTION
When variable substitution is not configured, WithVariablesDisabled() command is not issued currently. Issuing this command will skip looking for matching patterns in the script files and will prevent the error "Variable X Has No Value Defined" from occurring when variable substitution is not used and the script file has patterns such as $xxx$ that matches the pattern used by DbUp.